### PR TITLE
Breaking change, update to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "android-build"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,21 +22,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bitflags"
@@ -79,15 +49,6 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cesu8"
@@ -200,12 +161,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "gio"
@@ -362,15 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,15 +356,6 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-foundation",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -579,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "robius-authentication"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "android-build",
  "block2",
@@ -592,16 +529,9 @@ dependencies = [
  "polkit",
  "retry",
  "robius-android-env",
- "tokio",
  "windows",
  "windows-core",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "same-file"
@@ -715,16 +645,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.49",
-]
-
-[[package]]
-name = "tokio"
-version = "1.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
-dependencies = [
- "backtrace",
- "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "robius-authentication"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = [
     "Klim Tsoutsman <klim@tsoutsman.com>",
     "Kevin Boos <kevinaboos@gmail.com>",
     "Project Robius Maintainers",
 ]
-description = "Rust abstractions for multi-platform native authentication: biometrics, fingerprint, password, TouchID, FaceID, Windows Hello, etc."
+description = "Rust abstractions for multi-platform native authentication: biometrics, fingerprint, password, screen lock, TouchID, FaceID, Windows Hello, etc."
 documentation = "https://docs.rs/robius-authentication"
 homepage = "https://robius.rs/"
 keywords = ["robius", "authentication", "biometric", "password", "fingerprint"]
@@ -32,11 +32,12 @@ objc2 = "0.6.1"
 objc2-local-authentication = { version = "0.3.1", default-features = false, features = ["block2", "LAContext", "LAError"] }
 objc2-foundation = { version = "0.3.1", default-features = false, features = ["NSError", "NSString"] }
 
-[target.'cfg(any(target_vendor = "apple", target_os = "android"))'.dependencies.tokio]
-version = "1.35.1"
-default-features = false
-features = ["sync"]
-optional = true
+## disabled for now, sync the `async` feature isn't fully implemented.
+# [target.'cfg(any(target_vendor = "apple", target_os = "android"))'.dependencies.tokio]
+# version = "1.35.1"
+# default-features = false
+# features = ["sync"]
+# optional = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 polkit = "=0.17.0"
@@ -64,8 +65,11 @@ windows = { version = "0.56.0", default-features = false, features = [
 
 [features]
 default = []
+## This feature is not fully implemented yet, do not use it.
+##
 ## Enable this feature to expose non-blocking asynchronous authentication APIs.
-async = ["dep:tokio"]
+#async = ["dep:tokio"]
+
 ## Note: there is a UWP feature still in the code,
 ## but enabling it causes the app to freeze on Windows 11 Pro.
 ## Everything still works correctly without the UWP feature.

--- a/README.md
+++ b/README.md
@@ -8,17 +8,24 @@ Rust abstractions for multi-platform native authentication.
 
 This crate supports:
 * Apple: TouchID, FaceID, and regular username/password on both macOS and iOS.
-* Android: See below for additional steps.
+  * Requires the `NSFaceIDUsageDescription` key in your app's `Info.plist` file.
+* Android: Biometric prompt and regular screen lock. See below for additional steps.
   * Requires the `USE_BIOMETRIC` permission in your app's manifest.
 * Windows: Windows Hello (face recognition, fingerprint, PIN),
 plus winrt-based fallback for username/password.
 * Linux: [`polkit`]-based authentication using the desktop environment's prompt.
   * **Note: Linux support is currently incomplete.**
 
-## Usage on Android
 
-For authentication to work, the following must be added to your app's
-`AndroidManifest.xml`:
+## Usage on iOS
+To use this crate on iOS, you must add the following to your app's `Info.plist`:
+```plist
+<key>NSFaceIDUsageDescription</key>
+<string>Insert your usage description here</string>
+```
+
+## Usage on Android
+To use this crate on Android, you must add the following to your app's `AndroidManifest.xml`:
 ```xml
 <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 ```
@@ -47,8 +54,16 @@ let text = Text {
     windows: WindowsText::new("Title", "Description"),
 };
 
-let auth_result = Context::new(()).blocking_authenticate(text, &policy);
-...
+let callback = |auth_result| {
+    match auth_result {
+        Ok(_)  => log::info!("Authentication success!"),
+        Err(_) => log::error!(Authentication failed!"),
+    }
+};
+
+Context::new(())
+    .authenticate(text, &policy, callback)
+    .expect("Authentication failed");
 ```
 
 For more details about the prompt text, see the `Text` struct,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use robius_authentication::{
     AndroidText, BiometricStrength, Context, Policy, PolicyBuilder, Text, WindowsText,
 };
@@ -29,7 +27,7 @@ fn main() {
         &POLICY,
         |result| match result {
             Ok(_) => println!("Authentication successful"),
-            Err(e) => println!("Authentication failed: {}", e),
+            Err(e) => println!("Authentication failed: {:?}", e),
         },
     );
     
@@ -37,6 +35,6 @@ fn main() {
     // The callback will be called with the result of the authentication.
     // If `res` is `Err`, it indicates an error in the authentication policy or context setup.
     if let Err(e) = res {
-        eprintln!("Authentication failed: {}", e);
+        eprintln!("Authentication failed: {:?}", e);
     }
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use robius_authentication::{
     AndroidText, BiometricStrength, Context, Policy, PolicyBuilder, Text, WindowsText,
 };
@@ -22,9 +24,19 @@ const TEXT: Text = Text {
 fn main() {
     let context = Context::new(());
 
-    if context.blocking_authenticate(TEXT, &POLICY).is_ok() {
-        println!("Authorized");
-    } else {
-        println!("Unauthorized");
+    let res = context.authenticate(
+        TEXT,
+        &POLICY,
+        |result| match result {
+            Ok(_) => println!("Authentication successful"),
+            Err(e) => println!("Authentication failed: {}", e),
+        },
+    );
+    
+    // Note: if `res` is `Ok`, the authentication did not necessarily succeed. 
+    // The callback will be called with the result of the authentication.
+    // If `res` is `Err`, it indicates an error in the authentication policy or context setup.
+    if let Err(e) = res {
+        eprintln!("Authentication failed: {}", e);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,18 @@ pub enum Error {
     ///
     /// [Apple]: https://developer.apple.com/documentation/localauthentication/laerror/laerrorpasscodenotset
     PasscodeNotSet,
+    /// The user tapped the fallback button in the authentication dialog (e.g., "Use Password" instead),
+    /// but you selected an authentication policy that does not support password fallback.
+    ///
+    /// If you get this error, you either must handle the fallback yourself or enable the `password` option
+    /// in the policy builder, which will instruct the system to enable a password fallback option
+    /// in the authentication dialog.
+    ///
+    /// This error can occur on:
+    /// - [Apple]
+    ///
+    /// [Apple]: https://developer.apple.com/documentation/localauthentication/laerror/userfallback
+    UserFallback,
 
     // Android-specific errors
     UpdateRequired,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,15 @@
 //!     windows: WindowsText::new_truncated("Title", "Description"),
 //! };
 //!
+//! let callback = |auth_result| {
+//!     match auth_result {
+//!         Ok(_)  => log::info!("Authentication success!"),
+//!         Err(_) => log::error!(Authentication failed!"),
+//!     }
+//! };
+//!
 //! Context::new(())
-//!     .blocking_authenticate(text, &policy)
+//!     .authenticate(text, &policy, callback)
 //!     .expect("authentication failed");
 //! ```
 //!
@@ -108,25 +115,46 @@ impl Context {
         }
     }
 
-    /// Authenticates using the provided policy and message.
-    ///
-    /// Returns whether the authentication was successful.
-    #[inline]
-    #[cfg(feature = "async")]
-    pub async fn authenticate(
-        &self,
-        message: Text<'_, '_, '_, '_, '_, '_>,
-        policy: &Policy,
-    ) -> Result<()> {
-        self.inner.authenticate(message, &policy.inner).await
-    }
+    // Async authentication functions are currently not implemented. 
+    //
+    // /// Authenticates using the provided policy and message.
+    // ///
+    // /// Returns whether the authentication was successful.
+    // #[inline]
+    // #[cfg(feature = "async")]
+    // pub async fn authenticate_async(
+    //     &self,
+    //     message: Text<'_, '_, '_, '_, '_, '_>,
+    //     policy: &Policy,
+    // ) -> Result<()> {
+    //     self.inner.authenticate(message, &policy.inner).await
+    // }
 
-    /// Authenticates using the provided policy and message.
+    /// Displays an authentication prompt using the provided policy and message.
     ///
-    /// Returns whether the authentication was successful.
+    /// Note that the returned `Result` does not indicate whether
+    /// authentication was successful. This function returns `Ok(())`
+    /// to indicate that the authentication prompt was successfully displayed,
+    /// not that the user successfully authenticated.
+    ///
+    /// For that purpose, the given `callback` will be called
+    /// with a Result indicating whether authentication succeeded.
+    /// Note that the callback may be not be called at all,
+    /// but will always be called upon success.
+    ///
+    /// Thus, authentication failed if this function returns an error
+    /// **OR** if the `callback` is invoked with `Err(_)`.
     #[inline]
-    pub fn blocking_authenticate(&self, message: Text, policy: &Policy) -> Result<()> {
-        self.inner.blocking_authenticate(message, &policy.inner)
+    pub fn authenticate<F>(
+        &self,
+        message: Text,
+        policy: &Policy,
+        callback: F,
+    ) -> Result<()>
+    where
+        F: Fn(Result<()>) + Send + 'static,
+    {
+        self.inner.authenticate(message, &policy.inner, callback)
     }
 }
 
@@ -144,6 +172,10 @@ pub enum BiometricStrength {
 }
 
 /// A builder for conveniently defining a policy.
+///
+/// It is **highly recommended** to use the [`Self::new()`] (default) value
+/// to create a policy, as each platform behave differently
+/// when being requested to enable/disable various authentication methods.
 #[derive(Debug)]
 pub struct PolicyBuilder {
     inner: sys::PolicyBuilder,
@@ -216,7 +248,6 @@ impl PolicyBuilder {
     #[must_use]
     pub const fn build(self) -> Option<Policy> {
         Some(Policy {
-            // TODO: feature(const_try)
             inner: match self.inner.build() {
                 Some(inner) => inner,
                 None => return None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,10 @@ pub enum BiometricStrength {
 /// A builder for conveniently defining a policy.
 ///
 /// It is **highly recommended** to use the [`Self::new()`] (default) value
-/// to create a policy, as each platform behave differently
+/// to create a policy with all options enabled, because each platform acts differently
 /// when being requested to enable/disable various authentication methods.
+/// Enabling all options is the safest way to ensure that the authentication prompt
+/// will be displayed correctly on all platforms.
 #[derive(Debug)]
 pub struct PolicyBuilder {
     inner: sys::PolicyBuilder,

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -5,9 +5,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(target_vendor = "apple")] {
         mod apple;
         pub(crate) use apple::*;
-    } else if #[cfg(target_os = "linux")] {
-        mod linux;
-        pub(crate) use linux::*;
+    // } else if #[cfg(target_os = "linux")] { // linux is currently unsupported
+    //     mod linux;
+    //     pub(crate) use linux::*;
     } else if #[cfg(target_os = "windows")] {
         mod windows;
         pub(crate) use windows::*;

--- a/src/sys/linux.rs
+++ b/src/sys/linux.rs
@@ -36,7 +36,7 @@ impl PolicyBuilder {
     }
 }
 
-pub(crate) async fn authenticate(_message: &str, _: &Policy) -> Result<()> {
+pub(crate) async fn authenticate_async(_message: &str, _: &Policy) -> Result<()> {
     unimplemented!()
 }
 

--- a/src/sys/unsupported.rs
+++ b/src/sys/unsupported.rs
@@ -10,16 +10,18 @@ impl Context {
         Self
     }
 
-    #[cfg(feature = "async")]
-    pub(crate) async fn authenticate(
-        &self,
-        _: Text<'_, '_, '_, '_, '_, '_>,
-        _: &Policy,
-    ) -> Result<()> {
-        Err(Error::Unknown)
-    }
+    // TODO: fix the async authenticate function
+    //
+    // #[cfg(feature = "async")]
+    // pub(crate) async fn authenticate_async(
+    //     &self,
+    //     _: Text<'_, '_, '_, '_, '_, '_>,
+    //     _: &Policy,
+    // ) -> Result<()> {
+    //     Err(Error::Unknown)
+    // }
 
-    pub(crate) fn blocking_authenticate(&self, _: Text, _: &Policy) -> Result<()> {
+    pub(crate) fn authenticate(&self, _: Text, _: &Policy) -> Result<()> {
         Err(Error::Unknown)
     }
 }


### PR DESCRIPTION
* Redesign API to accept a callback that is called upon a successful authentication.
* Remove channel usage from iOS and Android, as the old design cannot be guaranteed to succeed in all cases
* Disable async features, since it is not yet implemented
* Clarify docs all around.

## Testing status
- [x] Android
- [x] iOS
- [x] macOS
- [x] Windows
- ~~Linux unsupported~~